### PR TITLE
Removed defaults for storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,6 @@ The process will look in the current working directory (where `nsindex` was call
 		apiPrefix: "",
 		urlPrefix: "",
 		port: 4444
-	},
-	storage: {
-		s3: {
-			id: "",
-			key: "",
-			bucket: "nonstop-packages"
-		},
-		rethink: {
-			host: "localhost",
-			port: 28015,
-			database: "nonstop"
-		}
 	}
 }
 ```

--- a/src/config.js
+++ b/src/config.js
@@ -21,18 +21,6 @@ module.exports = require( "configya" )
 			port: 4444,
 			urlPrefix: "",
 			apiPrefix: ""
-		},
-		storage: {
-			s3: {
-				id: "",
-				key: "",
-				bucket: "nonstop-packages-test"
-			},
-			rethink: {
-				host: "localhost",
-				port: 28015,
-				database: "nonstop"
-			}
 		}
 	}
 );


### PR DESCRIPTION
The way configya works, you can't remove keys with config so for this to run locally without rethinkdb or without s3, you have to edit the config.js file. This allows those to be opted into via config.json or env variables.