### PR TITLE
Added additional routes to client abilities

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,15 @@ module.exports = function( prompt, server ) {
 					return auth.changeActionRoles( "package.terms", [ "client" ], "add" );
 				},
 				function() {
+					return auth.changeActionRoles( "package.downloadFile", [ "client" ], "add" );
+				},
+				function() {
+					return auth.changeActionRoles( "package.downloadPackage", [ "client" ], "add" );
+				},
+				function() {
+					return auth.changeActionRoles( "package.promote", [ "client" ], "add" );
+				},
+				function() {
 					return auth.changeActionRoles( "host.self", [ "client" ], "add" );
 				},
 				function() {
@@ -59,6 +68,21 @@ module.exports = function( prompt, server ) {
 				},
 				function() {
 					return auth.changeActionRoles( "host.list", [ "client" ], "add" );
+				},
+				function() {
+					return auth.changeActionRoles( "host.status", [ "client" ], "add" );
+				},
+				function() {
+					return auth.changeActionRoles( "host.getEnvironment", [ "client" ], "add" );
+				},
+				function() {
+					return auth.changeActionRoles( "host.command", [ "client" ], "add" );
+				},
+				function() {
+					return auth.changeActionRoles( "host.configure", [ "client" ], "add" );
+				},
+				function() {
+					return auth.changeActionRoles( "host.changeEnvironment", [ "client" ], "add" );
 				},
 				function() {
 					return auth.changeActionRoles( "hook.self", [ "client" ], "add" );


### PR DESCRIPTION
A number of routes were only allowed for admin instead of for clients as well. I know we hope to get more fine grained role support in the future, but until then this will enable the client to perform the other actions on packages and hosts.